### PR TITLE
Change repeated IDs to classes for valid HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
+<!DOCTYPE html> <html lang="en">
 <head>
   <meta charset="utf-8">
   <title>Fancycle</title>
@@ -21,13 +20,13 @@
         <h1>Baby</h1>
 
         <div class="btn-group">
-          <button type="button" class="btn btn-default btn-xs" id="colorize">Colorize</button>
-          <button type="button" class="btn btn-default btn-xs" id="increase-text-size">Text +</button>
-          <button type="button" class="btn btn-default btn-xs" id="decrease-text-size">Text -</button>
+          <button type="button" class="btn btn-default btn-xs colorize">Colorize</button>
+          <button type="button" class="btn btn-default btn-xs increase-text-size">Text +</button>
+          <button type="button" class="btn btn-default btn-xs decrease-text-size">Text -</button>
         </div>
 
-        <h5 id="views">
-          Views: <span id="view-counter">0</span>
+        <h5 class="views">
+          Views: <span class="view-counter">0</span>
         </h5>
 
         <p>
@@ -67,13 +66,13 @@
         <h1>Come & Get It</h1>
 
         <div class="btn-group">
-          <button type="button" class="btn btn-default btn-xs" id="colorize">Colorize</button>
-          <button type="button" class="btn btn-default btn-xs" id="increase-text-size">Text +</button>
-          <button type="button" class="btn btn-default btn-xs" id="decrease-text-size">Text -</button>
+          <button type="button" class="btn btn-default btn-xs colorize">Colorize</button>
+          <button type="button" class="btn btn-default btn-xs increase-text-size">Text +</button>
+          <button type="button" class="btn btn-default btn-xs decrease-text-size">Text -</button>
         </div>
 
-        <h5 id="views">
-          Views: <span id="view-counter">0</span>
+        <h5 class="views">
+          Views: <span class="view-counter">0</span>
         </h5>
 
         <p>
@@ -113,13 +112,13 @@
         <h1>Wrecking Ball</h1>
 
         <div class="btn-group">
-          <button type="button" class="btn btn-default btn-xs" id="colorize">Colorize</button>
-          <button type="button" class="btn btn-default btn-xs" id="increase-text-size">Text +</button>
-          <button type="button" class="btn btn-default btn-xs" id="decrease-text-size">Text -</button>
+          <button type="button" class="btn btn-default btn-xs colorize">Colorize</button>
+          <button type="button" class="btn btn-default btn-xs increase-text-size">Text +</button>
+          <button type="button" class="btn btn-default btn-xs decrease-text-size">Text -</button>
         </div>
 
-        <h5 id="views">
-          Views: <span id="view-counter">0</span>
+        <h5 class="views">
+          Views: <span class="view-counter">0</span>
         </h5>
 
         <p>


### PR DESCRIPTION
The current index.html is invalid HTML as it has many repeating element IDs. Updated the index.html to use classes instead of IDs where there are repeated IDs.
